### PR TITLE
Initial feedback

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,14 +7,18 @@ from rudi import shop as shop
 with open('config.json') as json_file:
     config = json.load(json_file)
 
-# set logging level
-LOG_LEVEL = config['env'][0]['logging_level']
-# LOG_LEVEL = os.environ.get('LOG_LEVEL', 'WARNING')
-logging.basicConfig(level=LOG_LEVEL)
+# validate config file before trying to set logging level
+if not shop.Shop.validate_config(shop, config):
+    quit()
+else:
+    # # set logging level
+    LOG_LEVEL = config['env'][0]['logging_level']
+    # LOG_LEVEL = os.environ.get('LOG_LEVEL', 'WARNING')
+    logging.basicConfig(level=LOG_LEVEL)
 
-# start the shop!
-shop1 = shop.Shop()
-shop1.loadConfig(config)
+    # start the shop!
+    shop1 = shop.Shop()
+    shop1.loadConfig(config)
 
 
 

--- a/rudi/shop.py
+++ b/rudi/shop.py
@@ -13,8 +13,10 @@ class Shop():
         logging.debug("Shop started!")
 
 
-    def loadConfig(self, data):    
-        self.config = data
+    def loadConfig(self, config):    
+        if not self.validate_config(config):
+            return False
+        self.config = config
 
         print("\n" + "Welcome to " + self.getShopName())
         print("===================================" + "\n")
@@ -29,3 +31,17 @@ class Shop():
 
     def getShopName(self):
         return self.config['info'][0]['name']
+    
+    def validate_config(self, config): #
+        '''Receives loaded config file and validates it to make sure it's validates
+        Currently only checks for logging level and if it's not in the config file, will return False
+        
+        Returns True if valid. False if invalid'''
+        try:
+            LOG_LEVEL = config['env'][0]['logging_level']
+            return True
+        except:
+            #logging.debug("no logging level set in config file") # I don't think this line will work since there is no logging level
+            print("No logging level set in config file")
+            return False
+


### PR DESCRIPTION
Looking good! Here is some feedback:

- The branch name could be shorter (for next time)

Main.py
- Look for the logging value in the config and if not found to just skip the setting of the log level
- note: there is already a logging level that defaults to WARNING level, so we don't actually have to set/change it for the logger to work
- Remove direct call to validate config, since this is the initial boot we can just trust loadConfig to do this for us

shop.py
- rename validate_config method to validateConfig
- add these specific checks and log (not print) appropriate corresponding errors
1. check that the key itself exists
2. check that the value is one of the five supported values
- add debug logs into loadConfig for when a config was deemed valid or invalid 