### PR TITLE
allow docker to talk to host hardware

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,6 @@
 services:
   rudi-app:
+    privileged: true
     build:
       context: ./rudi-app
     environment:

--- a/rudi-app/docker-compose.yml
+++ b/rudi-app/docker-compose.yml
@@ -1,5 +1,6 @@
 services:
   rudi-app:
+    privileged: true
     build:
       context: .
     environment:


### PR DESCRIPTION
I needed to add this flag to make it work on the actual Pi. In the future when we are hardening for a production release, we may want to make separate docker compose files for dev and prod.