### PR TITLE
Making GPIO library work in Docker

### DIFF
--- a/rudi-app/Dockerfile
+++ b/rudi-app/Dockerfile
@@ -1,9 +1,9 @@
-FROM python:3.10-slim-buster
+FROM python:3.7.15-buster
 
 WORKDIR /usr/src/app
 
 COPY requirements.txt ./
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip3 install --no-cache-dir -r requirements.txt
 
 COPY . .
 

--- a/rudi-app/requirements.txt
+++ b/rudi-app/requirements.txt
@@ -2,3 +2,4 @@ adafruit-circuitpython-servokit
 gpiozero
 pymitter
 websockets
+RPi.GPIO


### PR DESCRIPTION
I was able to get RPi.GPIO playing nicely in Docker by changing the base image to not use a "slim" image build. Turns out that the slim builds don't include gcc and that gcc is needed by the RPi.GPIO installation script.

I also bumped it down from 3.10 to 3.7.15 because that seems like a closer version to what's shipping on the Pi these days. If there's a better/closer one in [this list of official python docker images](https://hub.docker.com/_/python) feel free to make that change on this branch in the docker file and we'll test more before we merge.


Testing this:
- Pull the branch down on a Pi
- Go into /rudi-app
- Run docker compose up --build
- Observe that there are no longer gpiozero warning flags about falling back to non-ideal pin factories because a more suitable GPIO library couldn't be found.