### PR TITLE
Framework for device-specific clean up code to run when system is shutting down

### DIFF
--- a/rudi-app/config-example.json
+++ b/rudi-app/config-example.json
@@ -3,7 +3,8 @@
         { "name" : "Mike's light and button shop" }
     ],
     "hardware" : {
-        "use_mock_pins" : true 
+        "use_mock_pins" : true,
+        "reset_devices_on_exit" : true
     },
     "devices" : [
         {

--- a/rudi-app/rudi/device.py
+++ b/rudi-app/rudi/device.py
@@ -50,10 +50,18 @@ class Device():
         #loop thru the provided config and subscribe to specified events
         for sub in self.config['subscriptions']:
             shop.em.subscribe(sub['listen_to'], sub['listen_for'], self.actions[sub['do_this']])
+
+        shop.em.subscribe("shop", "SHUTDOWN", self.on_shutdown)
     
     def on_init(self):
         # a safe place for subclasses to add init code without needed to override init
         self.emit_event("READY", {})
+        return True
+    
+    def on_shutdown(self, details):
+        # this is called when the shop shuts down
+        # devices are welcome to override this function and add custom logic
+        logging.debug(self.config['id'] + " is shutting down...")
         return True
 
     def register_event(self, event):

--- a/rudi-app/rudi/device_library.py
+++ b/rudi-app/rudi/device_library.py
@@ -91,13 +91,17 @@ class SuperSimpleLedLight(RudiDevice):
 
         self.emit_event("READY", {})
     
+    def on_shutdown(self, details):
+        logging.debug(self.config['id'] + " is shutting down...")
+        self.turn_off_light({})
+    
     def turn_on_light(self, args) :
         self.light.on()
         self.emit_event("TURNED_ON", {})
     
     def turn_off_light(self, args) :
         self.light.off()
-        self.emit_event("TURNED_ON", {})
+        self.emit_event("TURNED_OFF", {})
 
 class VoltageDetector(RudiDevice):
     

--- a/rudi-app/rudi/shop.py
+++ b/rudi-app/rudi/shop.py
@@ -1,4 +1,5 @@
 import logging
+import atexit
 from gpiozero import Device
 from gpiozero.pins.mock import MockFactory
 from . import device
@@ -27,6 +28,7 @@ class Shop():
         self.config = data
         logging.debug("Shop Config started loading")
         self.set_pin_mode()
+        self.set_shutdown_mode()
         self.device_manager.add_devices_from_config(self.config['devices'])
         logging.debug("Shop Config finished loading")
     
@@ -34,10 +36,19 @@ class Shop():
         return True
     
     def set_pin_mode(self):
-        if self.config['hardware']['use_mock_pins']:
-            Device.pin_factory = MockFactory()
-        return True
+        if "use_mock_pins" in self.config['hardware']:
+            if self.config['hardware']['use_mock_pins']:
+                Device.pin_factory = MockFactory()
+    
+    def set_shutdown_mode(self):
+        if "reset_devices_on_exit" in self.config['hardware']:
+            if self.config['hardware']['reset_devices_on_exit']:
+                atexit.register(self.shutdown)
 
     def get_shop_name(self):
         return self.config['info'][0]['name']
+    
+    def shutdown(self):
+        logging.debug("Shop is shutting down...")
+        em.emit("shop", "SHUTDOWN", {})
 


### PR DESCRIPTION
This new feature (which can be enabled or disabled from the config file using the "reset_devices_on_exit" flag) allows individual device classes to specify code they want to run when the program is exiting.

Details:
- The Device base class now has an on_shutdown method that is subscribed to the shop SHUTDOWN event
- Concrete Device classes can override that method if they want to do special shutdown stuff
- Shutdown event logic is in the Shop module and uses python's "atexit" module

To test:
- Disable the flag
- Run Rudi in Docker on a Pi in a configuration that results in a Super Simple LED Light being turned on
- Exit Rudi using Ctrl-C
- See that the light stays on
- Enable the flag in your config
- Run Rudi again the same way
- Exit Rudi using Ctrl-C
- See the additional log messages indicating that the on_shutdown code is running
- See that the light go off 