### PR TITLE
RPi.GPIO library installation fixes

### DIFF
--- a/rudi-app/Dockerfile
+++ b/rudi-app/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7.15-buster
+FROM python:3.9.15-buster
 
 WORKDIR /usr/src/app
 

--- a/rudi-app/Dockerfile
+++ b/rudi-app/Dockerfile
@@ -1,9 +1,9 @@
-FROM python:3.10-slim-buster
+FROM python:3.7.15-buster
 
 WORKDIR /usr/src/app
 
 COPY requirements.txt ./
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip3 install --no-cache-dir -r requirements.txt
 
 COPY . .
 

--- a/rudi-app/requirements.txt
+++ b/rudi-app/requirements.txt
@@ -2,3 +2,4 @@ adafruit-circuitpython-servokit
 gpiozero
 pymitter
 websockets
+RPi.GPIO


### PR DESCRIPTION
This one was a journey....

Note: There's a difference between being able to install the library and being able to use it (this fix is about installation).

**ISSUE:**
RPi.GPIO would not install on my Mac natively or within Docker. I assumed this these were for the same reason but it turns out:

**FINDINGS:**
Installing natively on Mac - It's true this isn't possible (see https://stackoverflow.com/questions/72522226/pip-install-rpi-gpio-on-mac)

Installing in Docker on Mac - This was because the package's installer needs gcc and that isn't in the "slim" version of our docker image.

**TESTING:**

In Docker on Mac:
- set use_mock_pins to true in config
- run "docker compose up --build" in the "rudi-app" folder and see that:
	- the pip installer does not fail
	- the app launches without failing

In Docker on Pi:
- set use_mock_pins to false in config
- run "docker compose up --build" in the "rudi-app" folder and see that:
	- the pip installer does not fail
	- the app launches without failing

Natively on Pi:
- set use_mock_pins to false in config
- run "LOG_LEVEL=DEBUG python3 main.py" in the "rudi-app" folder and see that:
	- the app launches without failing


**MORE NOTES:**
- to actually use this library it may be required to do conditional imports in Python
- business logic may also need to avoid invocation based on the "use_mock_pins" flag