### PR TITLE
Updated requirements.txt

### DIFF
--- a/rudi-app/requirements.txt
+++ b/rudi-app/requirements.txt
@@ -10,5 +10,5 @@ adafruit-platformdetect
 adafruit-circuitpython-ads1x15
 adafruit-circuitpython-mcp230xx
 adafruit-circuitpython-pca9685
-i2c-tools
-python-smbus
+#i2c-tools not sure what this is
+#python-smbus - needs to be installed by sudo apt install python3-smbus 

--- a/rudi-app/requirements.txt
+++ b/rudi-app/requirements.txt
@@ -10,5 +10,4 @@ adafruit-platformdetect
 adafruit-circuitpython-ads1x15
 adafruit-circuitpython-mcp230xx
 adafruit-circuitpython-pca9685
-#i2c-tools not sure what this is
 #python-smbus - needs to be installed by sudo apt install python3-smbus 


### PR DESCRIPTION
Requirements.txt had 2 entries that would cause it automatically making a venv to fail. 

Not sure what i2c-tools was installed for but it looks like it's not related to the pi

python-smbus needs to be installed in using apt install and not pip

